### PR TITLE
Fixes out-of-spec SSE streaming implementation

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,6 +173,7 @@ async function makeRequestToSlack(thread) {
     if (!thread.ws) {
         thread.ws = await openWebSocketConnection(thread.res);
         if (thread.stream) {
+            thread.res.setHeader("Content-Type", "text/event-stream");
             console_log("Opened stream for Claude's response.");
             thread.streamQueue = Promise.resolve();
             thread.ws.on("message", (message) => {

--- a/app.js
+++ b/app.js
@@ -591,7 +591,7 @@ function streamNextClaudeResponseChunk(message, res, thread) {
                     }]
                 };
                 try {
-                    res.write('\ndata: ' + JSON.stringify(streamData));
+                    res.write('\n\ndata: ' + JSON.stringify(streamData));
                 } catch (error) {
                     console_error(error)
                 }
@@ -790,7 +790,7 @@ function getClaudeResponse(message, res, thread) {
  */
 function finishStream(res) {
     try {
-        res.write('\ndata: [DONE]');
+        res.write('\n\ndata: [DONE]');
     } catch (error) {
         console_error(error)
     }


### PR DESCRIPTION
This PR addresses an issue wherein Slaude was delineating SSE messages with a single newline, instead of two newlines [as the spec requires](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#sending_events_from_the_server).

While this worked fine in SillyTavern before, I recently opened https://github.com/Cohee1207/SillyTavern/pull/340 to fix an unrelated streaming issue, and in so doing broke Slaude's streaming (because SillyTavern is now more strict and expects two newlines).