### PR TITLE
add cors header to allow slaude to be used by other front-end

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,13 @@
 import express from 'express';
 import axios from 'axios';
+import cors from 'cors';
 import FormData from 'form-data';
 import WebSocket from 'ws';
 import config from './config.js';
 import splitMessageInTwo from './utils.js';
 
 const app = express();
-
+app.use(cors());
 
 const typingString = "\n\n_Typing…_";
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.4.0",
+    "cors": "^2.8.5",
     "express": "^5.0.0-beta.1",
     "form-data": "^4.0.0",
     "ws": "^8.13.0"


### PR DESCRIPTION
Currently, the claude server is missing the CORs header, so it can only be used locally with Tavern.

Adding CORS headers will allow it to be consumed by other front-end like agnAI, Risu, Venus....